### PR TITLE
Added Net Standard 2.0 Two Factor Authentication support

### DIFF
--- a/Tests/AspNetCore.Identity.DocumentDb.Tests/AspNetCore.Identity.DocumentDb.Tests.csproj
+++ b/Tests/AspNetCore.Identity.DocumentDb.Tests/AspNetCore.Identity.DocumentDb.Tests.csproj
@@ -33,4 +33,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.0'">$(DefineConstants);NETCORE2</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/Tests/AspNetCore.Identity.DocumentDb.Tests/AspNetCore.Identity.DocumentDb.Tests.csproj
+++ b/Tests/AspNetCore.Identity.DocumentDb.Tests/AspNetCore.Identity.DocumentDb.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>AspNetCore.Identity.DocumentDb.Tests</AssemblyName>
     <PackageId>AspNetCore.Identity.DocumentDb.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/AspNetCore.Identity.DocumentDb/AspNetCore.Identity.DocumentDb.csproj
+++ b/src/AspNetCore.Identity.DocumentDb/AspNetCore.Identity.DocumentDb.csproj
@@ -45,4 +45,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETSTANDARD2</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/AspNetCore.Identity.DocumentDb/DocumentDbIdentityUser.cs
+++ b/src/AspNetCore.Identity.DocumentDb/DocumentDbIdentityUser.cs
@@ -77,5 +77,13 @@ namespace AspNetCore.Identity.DocumentDb
 
         [JsonProperty(PropertyName = "accessFailedCount")]
         public int AccessFailedCount { get; set; }
+
+#if NETSTANDARD2
+        [JsonProperty(PropertyName = "authenticatorKey")]
+        public string AuthenticatorKey { get; set; }
+
+        [JsonProperty(PropertyName = "recoveryCodes")]
+        public IEnumerable<string> RecoveryCodes { get; set; }
+#endif
     }
 }


### PR DESCRIPTION
- Implemented `NETSTANDARD2` support for `IUserAuthenticatorKeyStore<TUser>` and `IUserTwoFactorRecoveryCodeStore<TUser>` in the `DocumentDbUserStore` class
- Defined `NETSTANDARD2` precompilation variable in project `AspNetCore.Identity.DocumentDb`
- Defined `NETCORE2` precompilation variable in project `AspNetCore.Identity.DocumentDb.Tests`
- VS Test now runs Net Core 2.0 tests instead of Net Core 1.1