### PR TITLE
Handle DocumentClient creation

### DIFF
--- a/Samples/IdentitySample.Mvc/Startup.cs
+++ b/Samples/IdentitySample.Mvc/Startup.cs
@@ -50,9 +50,10 @@ namespace IdentitySample
         public void ConfigureServices(IServiceCollection services)
         {
             // Add DocumentDb client singleton instance (it's recommended to use a singleton instance for it)
-            services.AddSingleton<IDocumentClient>(InitializeDocumentClient(
+            services.AddDocumentClient(
                 Configuration.GetValue<Uri>("DocumentDbClient:EndpointUri"),
-                Configuration.GetValue<string>("DocumentDbClient:AuthorizationKey")));
+                Configuration.GetValue<string>("DocumentDbClient:AuthorizationKey"),
+                afterCreation: InitializeDocumentClient);
 
             // Add framework services.
 
@@ -99,11 +100,8 @@ namespace IdentitySample
             });
         }
 
-        private DocumentClient InitializeDocumentClient(Uri endpointUri, string authorizationKey)
+        private void InitializeDocumentClient(DocumentClient client)
         {
-            // Create a DocumentClient and an initial collection (if it does not exist yet) for sample purposes
-            DocumentClient client = new DocumentClient(endpointUri, authorizationKey, new ConnectionPolicy { EnableEndpointDiscovery = false });
-
             try
             {
                 // Does the DB exist?
@@ -144,8 +142,6 @@ namespace IdentitySample
                     return false;
                 });
             }
-
-            return client;
         }
     }
 }

--- a/Samples/IdentitySample.Mvc/Startup.cs
+++ b/Samples/IdentitySample.Mvc/Startup.cs
@@ -50,7 +50,7 @@ namespace IdentitySample
         public void ConfigureServices(IServiceCollection services)
         {
             // Add DocumentDb client singleton instance (it's recommended to use a singleton instance for it)
-            services.AddDocumentClient(
+            services.AddDefaultDocumentClientForIdentity(
                 Configuration.GetValue<Uri>("DocumentDbClient:EndpointUri"),
                 Configuration.GetValue<string>("DocumentDbClient:AuthorizationKey"),
                 afterCreation: InitializeDocumentClient);

--- a/Tests/AspNetCore.Identity.DocumentDb.Tests/Fixtures/DocumentDbFixture.cs
+++ b/Tests/AspNetCore.Identity.DocumentDb.Tests/Fixtures/DocumentDbFixture.cs
@@ -23,16 +23,7 @@ namespace AspNetCore.Identity.DocumentDb.Tests.Fixtures
 
         public DocumentDbFixture()
         {
-            // TODO: Until DocumentDB SDK exposes it's JSON.NET settings, we need to hijack the global settings to serialize claims
-            JsonConvert.DefaultSettings = () =>
-            {
-                return new JsonSerializerSettings()
-                {
-                    Converters = new List<JsonConverter>() { new JsonClaimConverter() }
-                };
-            };
-
-            Client = new DocumentClient(
+            Client = DocumentClientFactory.CreateClient(
                 serviceEndpoint: new Uri("https://localhost:8081", UriKind.Absolute),
                 authKeyOrResourceToken: "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
                 connectionPolicy: new ConnectionPolicy() { EnableEndpointDiscovery = false });

--- a/src/AspNetCore.Identity.DocumentDb/DocumentClientExtensions.cs
+++ b/src/AspNetCore.Identity.DocumentDb/DocumentClientExtensions.cs
@@ -11,7 +11,7 @@ namespace AspNetCore.Identity.DocumentDb
 {
     public static class DocumentClientExtensions
     {
-        public static DocumentClient AddDocumentClient(this IServiceCollection services, Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings = null, ConnectionPolicy connectionPolicy = null, ConsistencyLevel? consistencyLevel = null, Action<DocumentClient> afterCreation = null)
+        public static DocumentClient AddDefaultDocumentClientForIdentity(this IServiceCollection services, Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings = null, ConnectionPolicy connectionPolicy = null, ConsistencyLevel? consistencyLevel = null, Action<DocumentClient> afterCreation = null)
         {
             var documentClient = DocumentClientFactory.CreateClient(serviceEndpoint, authKeyOrResourceToken, serializerSettings, connectionPolicy, consistencyLevel);
             afterCreation?.Invoke(documentClient);

--- a/src/AspNetCore.Identity.DocumentDb/DocumentClientExtensions.cs
+++ b/src/AspNetCore.Identity.DocumentDb/DocumentClientExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using AspNetCore.Identity.DocumentDb.Tools;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+
+namespace AspNetCore.Identity.DocumentDb
+{
+    public static class DocumentClientExtensions
+    {
+        public static DocumentClient AddDocumentClient(this IServiceCollection services, Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings = null, ConnectionPolicy connectionPolicy = null, ConsistencyLevel? consistencyLevel = null, Action<DocumentClient> afterCreation = null)
+        {
+            var documentClient = DocumentClientFactory.CreateClient(serviceEndpoint, authKeyOrResourceToken, serializerSettings, connectionPolicy, consistencyLevel);
+            afterCreation?.Invoke(documentClient);
+            services.AddSingleton<IDocumentClient>(documentClient);
+            return documentClient;
+        }
+    }
+}

--- a/src/AspNetCore.Identity.DocumentDb/Properties/AssemblyInfo.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Properties/AssemblyInfo.cs
@@ -17,3 +17,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8d8507ba-f5ac-408d-9f4f-42966a72a1b5")]
+
+[assembly: InternalsVisibleToAttribute("AspNetCore.Identity.DocumentDb.Tests")]

--- a/src/AspNetCore.Identity.DocumentDb/Tools/DocumentClientFactory.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Tools/DocumentClientFactory.cs
@@ -11,6 +11,8 @@ namespace AspNetCore.Identity.DocumentDb.Tools
         {
             serializerSettings = serializerSettings ?? new JsonSerializerSettings();
             serializerSettings.Converters.Add(new JsonClaimConverter());
+            serializerSettings.Converters.Add(new JsonClaimsPrincipalConverter());
+            serializerSettings.Converters.Add(new JsonClaimsIdentityConverter());
 
 #if NETSTANDARD2
             return new DocumentClient(serviceEndpoint, authKeyOrResourceToken, serializerSettings, connectionPolicy, consistencyLevel);

--- a/src/AspNetCore.Identity.DocumentDb/Tools/DocumentClientFactory.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Tools/DocumentClientFactory.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json;
 
 namespace AspNetCore.Identity.DocumentDb.Tools
 {
-    public static class DocumentClientFactory
+    internal static class DocumentClientFactory
     {
-        public static DocumentClient CreateClient(Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings = null, ConnectionPolicy connectionPolicy = null, ConsistencyLevel? consistencyLevel = null)
+        internal static DocumentClient CreateClient(Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings = null, ConnectionPolicy connectionPolicy = null, ConsistencyLevel? consistencyLevel = null)
         {
             serializerSettings = serializerSettings ?? new JsonSerializerSettings();
             serializerSettings.Converters.Add(new JsonClaimConverter());

--- a/src/AspNetCore.Identity.DocumentDb/Tools/DocumentClientFactory.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Tools/DocumentClientFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Newtonsoft.Json;
+
+namespace AspNetCore.Identity.DocumentDb.Tools
+{
+    public static class DocumentClientFactory
+    {
+        public static DocumentClient CreateClient(Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings = null, ConnectionPolicy connectionPolicy = null, ConsistencyLevel? consistencyLevel = null)
+        {
+            serializerSettings = serializerSettings ?? new JsonSerializerSettings();
+            serializerSettings.Converters.Add(new JsonClaimConverter());
+
+#if NETSTANDARD2
+            return new DocumentClient(serviceEndpoint, authKeyOrResourceToken, serializerSettings, connectionPolicy, consistencyLevel);
+#else
+            // DocumentDB SDK only supports setting the JsonSerializerSettings on versions after NetStandard 2.0
+            JsonConvert.DefaultSettings = () => serializerSettings;
+            return new DocumentClient(serviceEndpoint, authKeyOrResourceToken, connectionPolicy, consistencyLevel);
+#endif
+        }
+    }
+}


### PR DESCRIPTION
I know it's not really the responsability of the library to handle the DocumentClient creation. That's a fact.

But... It does require some custom JsonSerializationSettings to be set on the moment of the creation, and so, it is a bit lacking a simple way for users to be able to get an app running with minimal changes.

This PR focus on adding an extensions to the ServiceColletion to allow a simple DocumentClient registration that also set's the JsonSerializationSettings needed to run.

Now, these settings are only present on newer versions of the DocumentClient SDK, so, I think you have a few options here, either you go with this #IF directives, or you pin some older versions and keep only developing for newer versions, that if we can't push the required versions to some newer ones. The dependencies that are pinned to the project are already 8 months old.

On the Documentation we can state that is not required to create the DocumentClient instance with this Extension, as long as the JsonSerializationSettings are set.