### PR TITLE
Add converters for to support Identity 2 for dotnet core

### DIFF
--- a/src/AspNetCore.Identity.DocumentDb/IdentityDocumentDbBuilderExtensions.cs
+++ b/src/AspNetCore.Identity.DocumentDb/IdentityDocumentDbBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace AspNetCore.Identity.DocumentDb
             {
                 return new JsonSerializerSettings()
                 {
-                    Converters = new List<JsonConverter>() { new JsonClaimConverter() }
+                    Converters = new List<JsonConverter>() { new JsonClaimConverter(), new JsonClaimsPrincipalConverter(), new JsonClaimsIdentityConverter() }
                 };
             };
 

--- a/src/AspNetCore.Identity.DocumentDb/Tools/JsonClaimsIdentityConverter.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Tools/JsonClaimsIdentityConverter.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AspNetCore.Identity.DocumentDb.Tools 
+{
+    public class JsonClaimsIdentityConverter : JsonConverter 
+    {
+        public override bool CanConvert(Type objectType) 
+        {
+            return typeof(ClaimsIdentity) == objectType;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) 
+        {
+            var jObject = JObject.Load(reader);
+            var claims = jObject[nameof(ClaimsIdentity.Claims)].ToObject<IEnumerable<Claim>>(serializer);
+            var authenticationType = (string)jObject[nameof(ClaimsIdentity.AuthenticationType)];
+            var nameClaimType = (string)jObject[nameof(ClaimsIdentity.NameClaimType)];
+            var roleClaimType = (string)jObject[nameof(ClaimsIdentity.RoleClaimType)];
+            return new ClaimsIdentity(claims, authenticationType, nameClaimType, roleClaimType);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) 
+        {
+            var claimsIdentity = (ClaimsIdentity)value;
+            var jObject = new JObject 
+            {
+                { nameof(ClaimsIdentity.AuthenticationType), claimsIdentity.AuthenticationType },
+                { nameof(ClaimsIdentity.IsAuthenticated), claimsIdentity.IsAuthenticated },
+                { nameof(ClaimsIdentity.Actor), claimsIdentity.Actor == null ? null : JObject.FromObject(claimsIdentity.Actor, serializer) },
+                { nameof(ClaimsIdentity.BootstrapContext), claimsIdentity.BootstrapContext == null ? null : JObject.FromObject(claimsIdentity.BootstrapContext, serializer) },
+                { nameof(ClaimsIdentity.Claims), new JArray(claimsIdentity.Claims.Select(x => JObject.FromObject(x, serializer))) },
+                { nameof(ClaimsIdentity.Label), claimsIdentity.Label },
+                { nameof(ClaimsIdentity.Name), claimsIdentity.Name },
+                { nameof(ClaimsIdentity.NameClaimType), claimsIdentity.NameClaimType },
+                { nameof(ClaimsIdentity.RoleClaimType), claimsIdentity.RoleClaimType }
+            };
+            
+            jObject.WriteTo(writer);
+        }
+    }
+}

--- a/src/AspNetCore.Identity.DocumentDb/Tools/JsonClaimsPrincipalConverter.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Tools/JsonClaimsPrincipalConverter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AspNetCore.Identity.DocumentDb.Tools 
+{
+    public class JsonClaimsPrincipalConverter : JsonConverter 
+    {
+        public override bool CanConvert(Type objectType) 
+        {
+            return typeof(ClaimsPrincipal) == objectType;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) 
+        {
+            var jObject = JObject.Load(reader);
+            var identities = jObject[nameof(ClaimsPrincipal.Identities)].ToObject<IEnumerable<ClaimsIdentity>>(serializer);
+            return new ClaimsPrincipal(identities);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) 
+        {
+            var claimsPrincipal = (ClaimsPrincipal)value;
+            var jObject = new JObject 
+            {
+                { nameof(ClaimsPrincipal.Identities), new JArray(claimsPrincipal.Identities.Select(x => JObject.FromObject(x, serializer))) },
+            };
+
+            jObject.WriteTo(writer);
+        }
+    }
+}


### PR DESCRIPTION
Add converters for ClaimsPrincipal and ClaimsIdentity to support Identity 2 for dotnet core
I gave an attempt to add converters to support identity on dotnet core.
I was experiencing issues detailed in this [issue](https://github.com/aspnet/Identity/issues/1364#issuecomment-323767718)

I think it stems down to ClaimsPrincipal Identity property which is only an interface variable. At least thats where it failed for me once i started to try and manually serialize this object. I am not that familiar with Identity framework to know how others might override classes and interfaces to fit different scenarios and what might be needed here.

I am unsure if this is how we would want to serialized the ClaimsPrincipal though. I am using 3rd party login providers in my solution.