### PR TITLE
UserManager has RemovePasswordAsync method which call UpdatePasswordH…

### DIFF
--- a/src/AspNetCore.Identity.DocumentDb/Stores/DocumentDbUserStore.cs
+++ b/src/AspNetCore.Identity.DocumentDb/Stores/DocumentDbUserStore.cs
@@ -570,11 +570,6 @@ namespace AspNetCore.Identity.DocumentDb.Stores
                 throw new ArgumentNullException(nameof(user));
             }
 
-            if (passwordHash == null)
-            {
-                throw new ArgumentNullException(nameof(passwordHash));
-            }
-
             user.PasswordHash = passwordHash;
 
             return Task.CompletedTask;


### PR DESCRIPTION
…ash with an empty password. So SetPasswordHashAsync should support empty password hash

----------
[03:01:38 Error] Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware
An unhandled exception has occurred while executing the request.
System.ArgumentNullException: Value cannot be null. (Parameter 'passwordHash')
   at AspNetCore.Identity.DocumentDb.Stores.DocumentDbUserStore`2.SetPasswordHashAsync(TUser user, String passwordHash, CancellationToken cancellationToken) in E:\projects\IELTS Write trenning\ieltsPractise-identity-microservice\AspNetCore.Identity.DocumentDb\Stores\DocumentDbUserStore.cs:line 578
   at Microsoft.AspNetCore.Identity.UserManager`1.UpdatePasswordHash(IUserPasswordStore`1 passwordStore, TUser user, String newPassword, Boolean validatePassword)
   at Microsoft.AspNetCore.Identity.UserManager`1.RemovePasswordAsync(TUser user)